### PR TITLE
Update text for initial status message

### DIFF
--- a/lib/biokbase/workflow/KBW.py
+++ b/lib/biokbase/workflow/KBW.py
@@ -49,7 +49,7 @@ def run_async (config, ctx, args) :
 
 
   # UJS
-  status = 'Initializing'
+  status = 'Queued and waiting to start'
   description = method_hash["ujs_description"]
   progress = { 'ptype' : method_hash["ujs_ptype"], 'max' : method_hash["ujs_mstep"] };
 


### PR DESCRIPTION
Users should be less confused about the status of a job if the initial message indicates that the job is waiting in the AWE queue.
